### PR TITLE
Always show last refreshed message

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -177,9 +177,9 @@ class Window(QMainWindow):
         Display a message indicating the time of last sync with the server.
         """
         if updated_on:
-            self.update_activity_status(_("Last Refresh: {}").format(updated_on.humanize()))
+            self.update_sync_status(_("Last Refresh: {}").format(updated_on.humanize()))
         else:
-            self.update_activity_status(_("Last Refresh: never"))
+            self.update_sync_status(_("Last Refresh: never"))
 
     def set_logged_in_as(self, db_user: User) -> None:
         """
@@ -194,6 +194,13 @@ class Window(QMainWindow):
         """
         self.left_pane.set_logged_out()
         self.top_pane.set_logged_out()
+
+    def update_sync_status(self, message: str, duration: int = 0) -> None:
+        """
+        Display an activity status message to the user. Optionally, supply a duration
+        (in milliseconds), the default will continuously show the message.
+        """
+        self.top_pane.update_sync_status(message, duration)
 
     def update_activity_status(self, message: str, duration: int = 0) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -125,10 +125,6 @@ class TopPane(QWidget):
         layout.setContentsMargins(10, 0, 0, 0)
         layout.setSpacing(0)
 
-        status_layout = QHBoxLayout()
-        status_layout.setContentsMargins(0, 0, 0, 0)
-        status_layout.setSpacing(0)
-
         # Sync icon
         self.sync_icon = SyncIcon()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -125,36 +125,43 @@ class TopPane(QWidget):
         layout.setContentsMargins(10, 0, 0, 0)
         layout.setSpacing(0)
 
+        status_layout = QHBoxLayout()
+        status_layout.setContentsMargins(0, 0, 0, 0)
+        status_layout.setSpacing(0)
+
         # Sync icon
         self.sync_icon = SyncIcon()
 
         # Activity status bar
         self.activity_status_bar = ActivityStatusBar()
 
+        self.sync_status_bar = SyncStatusBar()
+
         # Error status bar
         self.error_status_bar = ErrorStatusBar()
 
-        # Create space the size of the status bar to keep the error status bar centered
         spacer = QWidget()
-
-        # Create space ths size of the sync icon to keep the error status bar centered
         spacer2 = QWidget()
-        spacer2.setFixedWidth(42)
+
+        # Create space the size of the status bar to keep the error status bar centered
+        spacer3 = QWidget()
+        spacer3.setFixedWidth(42)
 
         # Set height of top pane to 42 pixels
         self.setFixedHeight(42)
         self.sync_icon.setFixedHeight(42)
         self.activity_status_bar.setFixedHeight(42)
         self.error_status_bar.setFixedHeight(42)
-        spacer.setFixedHeight(42)
-        spacer2.setFixedHeight(42)
 
         # Add widgets to layout
         layout.addWidget(self.sync_icon, 1)
-        layout.addWidget(self.activity_status_bar, 1)
+        status_layout.addWidget(self.sync_status_bar, 1)
+        status_layout.addWidget(self.activity_status_bar, 1)
+        status_layout.addWidget(spacer, 1)
+        layout.addLayout(status_layout, 1)
         layout.addWidget(self.error_status_bar, 1)
-        layout.addWidget(spacer, 1)
         layout.addWidget(spacer2, 1)
+        layout.addWidget(spacer3, 1)
 
     def setup(self, controller: Controller) -> None:
         self.sync_icon.setup(controller)
@@ -167,6 +174,9 @@ class TopPane(QWidget):
     def set_logged_out(self) -> None:
         self.sync_icon.disable()
         self.setPalette(self.offline_palette)
+
+    def update_sync_status(self, message: str, duration: int) -> None:
+        self.sync_status_bar.update_message(message, duration)
 
     def update_activity_status(self, message: str, duration: int) -> None:
         self.activity_status_bar.update_message(message, duration)
@@ -274,6 +284,28 @@ class SyncIcon(QLabel):
         self.sync_animation.setScaledSize(QSize(24, 20))
         self.setMovie(self.sync_animation)
         self.sync_animation.start()
+
+
+class SyncStatusBar(QStatusBar):
+    """
+    A status bar for displaying messages about metadata sync activity to the user. Messages will be
+    displayed for a given duration or until the message updated with a new message.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        # Set css id
+        self.setObjectName("SyncStatusBar")
+
+        # Remove grip image at bottom right-hand corner
+        self.setSizeGripEnabled(False)
+
+    def update_message(self, message: str, duration: int) -> None:
+        """
+        Display a status message to the user.
+        """
+        self.showMessage(message, duration)
 
 
 class ActivityStatusBar(QStatusBar):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -132,20 +132,26 @@ class TopPane(QWidget):
         # Sync icon
         self.sync_icon = SyncIcon()
 
+        # Sync status bar with fixed width so that the left side of the
+        # activity status bar lines up with left pane
+        self.sync_status_bar = SyncStatusBar()
+        self.sync_status_bar.setFixedWidth(171)
+
         # Activity status bar
         self.activity_status_bar = ActivityStatusBar()
-
-        self.sync_status_bar = SyncStatusBar()
 
         # Error status bar
         self.error_status_bar = ErrorStatusBar()
 
-        spacer = QWidget()
-        spacer2 = QWidget()
+        # Create spacers the size of the sync icon and sync and activity status bars
+        # so that the error status bar is centered
+        sync_icon_spacer = QWidget()
+        sync_icon_spacer.setFixedWidth(42)
 
-        # Create space the size of the status bar to keep the error status bar centered
-        spacer3 = QWidget()
-        spacer3.setFixedWidth(42)
+        sync_status_bar_spacer = QWidget()
+        sync_status_bar_spacer.setFixedWidth(171)
+
+        activity_status_bar_spacer = QWidget()
 
         # Set height of top pane to 42 pixels
         self.setFixedHeight(42)
@@ -155,13 +161,14 @@ class TopPane(QWidget):
 
         # Add widgets to layout
         layout.addWidget(self.sync_icon, 1)
-        status_layout.addWidget(self.sync_status_bar, 1)
-        status_layout.addWidget(self.activity_status_bar, 1)
-        status_layout.addWidget(spacer, 1)
-        layout.addLayout(status_layout, 1)
+        layout.addWidget(self.sync_status_bar, 1)
+        layout.addWidget(self.activity_status_bar, 1)
+
         layout.addWidget(self.error_status_bar, 1)
-        layout.addWidget(spacer2, 1)
-        layout.addWidget(spacer3, 1)
+
+        layout.addWidget(activity_status_bar_spacer, 1)
+        layout.addWidget(sync_status_bar_spacer, 1)
+        layout.addWidget(sync_icon_spacer, 1)
 
     def setup(self, controller: Controller) -> None:
         self.sync_icon.setup(controller)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -406,6 +406,7 @@ class Controller(QObject):
         # Create a timer to show the time since the last sync
         self.show_last_sync_timer = QTimer()
         self.show_last_sync_timer.timeout.connect(self.show_last_sync)
+        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
         # Path to the file containing the timestamp since the last sync with the server
         # TODO: Remove this code once the sync timestamp is tracked instead in svs.sqlite
@@ -500,11 +501,9 @@ class Controller(QObject):
         self.gui.update_error_status(
             _("The SecureDrop server cannot be reached. Trying to reconnect..."), duration=0
         )
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
     def resume_queues(self) -> None:
         self.api_job_queue.resume_queues()
-        self.show_last_sync_timer.stop()
 
         # clear error status in case queue was paused resulting in a permanent error message
         self.gui.clear_error_status()
@@ -547,8 +546,6 @@ class Controller(QObject):
         self.call_api(
             self.api.authenticate, self.on_authenticate_success, self.on_authenticate_failure
         )
-        self.show_last_sync_timer.stop()
-        self.set_status("")
 
     def on_authenticate_success(self, result):  # type: ignore [no-untyped-def]
         """
@@ -611,8 +608,6 @@ class Controller(QObject):
         self.gui.clear_clipboard()
         self.gui.show_main_window()
         self.update_sources()
-        self.show_last_sync()
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
     def on_action_requiring_login(self) -> None:
         """
@@ -810,8 +805,6 @@ class Controller(QObject):
         self.api_job_queue.stop()
         self.gui.logout()
 
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
-        self.show_last_sync()
         self.is_authenticated = False
 
     def invalidate_token(self) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -407,6 +407,7 @@ class Controller(QObject):
         self.show_last_sync_timer = QTimer()
         self.show_last_sync_timer.timeout.connect(self.show_last_sync)
         self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
+        self.show_last_sync()
 
         # Path to the file containing the timestamp since the last sync with the server
         # TODO: Remove this code once the sync timestamp is tracked instead in svs.sqlite
@@ -649,6 +650,7 @@ class Controller(QObject):
         """
         with open(self.last_sync_filepath, "w") as f:
             f.write(arrow.now().format())
+        self.show_last_sync()
 
         missing_files = storage.update_missing_files(self.data_dir, self.session)
         for missed_file in missing_files:

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -16,6 +16,14 @@ QWidget {
     color: #fff;
 }
 
+#SyncStatusBar {
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 12px;
+    color: #d3d8ea;
+    background: transparent;
+}
+
 #ActivityStatusBar {
     font-family: 'Source Sans Pro';
     font-weight: 600;


### PR DESCRIPTION
# Description
Fixes [#1608.](https://github.com/freedomofpress/securedrop-client/issues/1608)

- Add a new sync status bar between the sync icon and the existing activity status bar
- Always show sync status (e.g. "Last refresh: just now") in the new sync status bar, rather than only showing it when the user is logged out or offline.

Example (including the change in #1 to show the two features interacting):

https://user-images.githubusercontent.com/17057932/207411569-ff354ff0-8dd8-4d56-a973-6b9b87f31a91.mov

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
