### PR TITLE
Batch delete source accounts

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -13,7 +13,6 @@ from PyQt5.QtWidgets import QAction, QDialog, QMenu
 from securedrop_client import state
 from securedrop_client.db import Source
 from securedrop_client.logic import Controller
-from securedrop_client.resources import load_icon
 
 
 class DownloadConversation(QAction):
@@ -110,13 +109,15 @@ class DeleteSourcesAction(QAction):
         self.setEnabled(False)  # disabled until sources are selected
 
     def trigger(self) -> None:
-        sources = list(self.controller.checked_sources)
+        checked_sources = self.controller.get_checked_sources()
 
         if self.controller.api is None:
             self.controller.on_action_requiring_login()
         else:
-            confirmation_dialog = self._confirmation_dialog(sources)
-            confirmation_dialog.accepted.connect(lambda: self.controller.delete_sources(sources))
+            confirmation_dialog = self._confirmation_dialog(checked_sources)
+            confirmation_dialog.accepted.connect(
+                lambda: self.controller.delete_sources(checked_sources)
+            )
             confirmation_dialog.exec()
 
 

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -103,7 +103,7 @@ class DeleteSourcesAction(QAction):
     ) -> None:
         self.controller = controller
         self._confirmation_dialog = confirmation_dialog
-        text = _("Delete Multiple Source Accounts")
+        text = _("Delete Source Accounts")
 
         super().__init__(text, parent=parent)
         self.triggered.connect(self.trigger)
@@ -111,7 +111,6 @@ class DeleteSourcesAction(QAction):
 
     def trigger(self) -> None:
         sources = list(self.controller.checked_sources)
-        print(sources)
 
         if self.controller.api is None:
             self.controller.on_action_requiring_login()

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -105,9 +105,9 @@ class DeleteSourcesAction(QAction):
         self._confirmation_dialog = confirmation_dialog
         text = _("Delete Multiple Source Accounts")
 
-        # load_icon("trash.png"),
         super().__init__(text, parent=parent)
         self.triggered.connect(self.trigger)
+        self.setEnabled(False)  # disabled until sources are selected
 
     def trigger(self) -> None:
         sources = list(self.controller.checked_sources)

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -5,7 +5,7 @@ Over time, this module could become the interface between
 the GUI and the controller.
 """
 from gettext import gettext as _
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import QAction, QDialog, QMenu
@@ -89,6 +89,34 @@ class DeleteSourceAction(QAction):
             self.controller.on_action_requiring_login()
         else:
             self._confirmation_dialog.exec()
+
+
+class DeleteSourcesAction(QAction):
+    """Use this action to delete multiple source records."""
+
+    def __init__(
+        self,
+        parent: QMenu,
+        controller: Controller,
+        confirmation_dialog: Callable[[List[str]], QDialog],
+    ) -> None:
+        self.controller = controller
+        self._confirmation_dialog = confirmation_dialog
+        text = _("Delete Multiple Source Accounts")
+
+        super().__init__(text, parent)
+        self.triggered.connect(self.trigger)
+
+    def trigger(self) -> None:
+        sources = list(self.controller.checked_sources)
+        print(sources)
+
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+        else:
+            confirmation_dialog = self._confirmation_dialog(sources)
+            confirmation_dialog.accepted.connect(lambda: self.controller.delete_sources(sources))
+            confirmation_dialog.exec()
 
 
 class DeleteConversationAction(QAction):

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import QAction, QDialog, QMenu
 from securedrop_client import state
 from securedrop_client.db import Source
 from securedrop_client.logic import Controller
+from securedrop_client.resources import load_icon
 
 
 class DownloadConversation(QAction):
@@ -104,7 +105,8 @@ class DeleteSourcesAction(QAction):
         self._confirmation_dialog = confirmation_dialog
         text = _("Delete Multiple Source Accounts")
 
-        super().__init__(text, parent)
+        # load_icon("trash.png"),
+        super().__init__(text, parent=parent)
         self.triggered.connect(self.trigger)
 
     def trigger(self) -> None:

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -229,3 +229,6 @@ class Window(QMainWindow):
         cb = QApplication.clipboard()
         cb.clear()
         cb.clear(QClipboard.Selection)
+
+    def toggle_delete_sources_button_enabled(self, enabled: bool):
+        self.main_view.toggle_delete_sources_button_enabled(enabled)

--- a/securedrop_client/gui/source/delete/dialog.py
+++ b/securedrop_client/gui/source/delete/dialog.py
@@ -16,7 +16,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from gettext import gettext as _, ngettext
+from gettext import gettext as _
+from gettext import ngettext
 from typing import List
 
 from securedrop_client.db import Source

--- a/securedrop_client/gui/source/delete/dialog.py
+++ b/securedrop_client/gui/source/delete/dialog.py
@@ -72,7 +72,7 @@ class DeleteSourcesDialog(ModalDialog):
         self.sources = sources
 
         self.body.setText(self.make_body_text())
-        self.continue_button.setText(_("YES, DELETE ALL SOURCE ACCOUNT"))
+        self.continue_button.setText(_("YES, DELETE THESE SOURCE ACCOUNTS"))
         self.cancel_button.setDefault(True)
         self.cancel_button.setFocus()
         self.confirmation_label.setText(_("Are you sure this is what you want?"))
@@ -92,7 +92,7 @@ class DeleteSourcesDialog(ModalDialog):
             ),
             "</b></p>",
             "<p><b>",
-            _("When the entire account for all source are deleted:"),
+            _("When the entire accounts for these sources are deleted:"),
             "</b></p>",
             "<p><b>\u2219</b>&nbsp;",
             _("The sources will not be able to log in with their codename again."),

--- a/securedrop_client/gui/source/delete/dialog.py
+++ b/securedrop_client/gui/source/delete/dialog.py
@@ -16,7 +16,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from gettext import gettext as _
+from gettext import gettext as _, ngettext
+from typing import List
 
 from securedrop_client.db import Source
 from securedrop_client.gui.base import ModalDialog
@@ -60,3 +61,49 @@ class DeleteSourceDialog(ModalDialog):
         return "".join(message_tuple).format(
             source="<b>{}</b>".format(self.source.journalist_designation)
         )
+
+
+class DeleteSourcesDialog(ModalDialog):
+    """Used to confirm deletion of multiple source accounts."""
+
+    def __init__(self, sources: List[str]) -> None:
+        super().__init__(show_header=False, dangerous=True)
+
+        self.sources = sources
+
+        self.body.setText(self.make_body_text())
+        self.continue_button.setText(_("YES, DELETE ALL SOURCE ACCOUNT"))
+        self.cancel_button.setDefault(True)
+        self.cancel_button.setFocus()
+        self.confirmation_label.setText(_("Are you sure this is what you want?"))
+        self.adjustSize()
+
+    def make_body_text(self) -> str:
+        num_sources = len(self.sources)
+        message_tuple = (
+            "<style>",
+            "p {{white-space: nowrap;}}",
+            "</style>",
+            "<p><b>",
+            ngettext(
+                "You are about to delete 1 source account",
+                f"You are about to delete {num_sources} accounts",
+                num_sources,
+            ),
+            "</b></p>",
+            "<p><b>",
+            _("When the entire account for all source are deleted:"),
+            "</b></p>",
+            "<p><b>\u2219</b>&nbsp;",
+            _("The sources will not be able to log in with their codename again."),
+            "</p>",
+            "<p><b>\u2219</b>&nbsp;",
+            _("Your organization will not be able to send them replies."),
+            "</p>",
+            "<p><b>\u2219</b>&nbsp;",
+            _("All files and messages from the sources will also be destroyed."),
+            "</p>",
+            "<p>&nbsp;</p>",
+        )
+
+        return "".join(message_tuple)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -647,8 +647,7 @@ class MainView(QWidget):
         self.view_layout.addWidget(self.empty_conversation_view)
 
         self.sources_pane_holder = QWidget()
-        # TODO - remove this hard-coded width
-        self.sources_pane_holder.setMaximumWidth(540)
+        # self.sources_pane_holder.setMaximumWidth(540)
         self.sources_pane_holder.setObjectName("MainView_sources_pane_holder")
         self.sources_pane_layout = QVBoxLayout()
         self.sources_pane_layout.setContentsMargins(0, 0, 0, 0)
@@ -1345,7 +1344,6 @@ class SourceWidget(QWidget):
         self.checkbox = QCheckBox()
         self.checkbox.setObjectName("SourceWidget_checkbox")
         self.checkbox.setStyleSheet(self.SOURCE_CHECKBOX_CSS)
-        self.checkbox.source_uuid = self.source.uuid
         self.checkbox.toggled.connect(controller.maybe_toggle_delete_sources_button_enabled)
 
         self.timestamp = QLabel()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1360,6 +1360,7 @@ class SourceWidget(QWidget):
         source_widget_layout.addWidget(self.name, 0, 2, 1, 1)
         source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1)
         source_widget_layout.addWidget(self.paperclip_disabled, 0, 3, 1, 1)
+        source_widget_layout.addWidget(self.checkbox, 1, 0, 1, 1)
         source_widget_layout.addWidget(self.preview, 1, 2, 1, 1, alignment=Qt.AlignLeft)
         source_widget_layout.addWidget(self.deletion_indicator, 1, 2, 1, 1)
         source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -646,14 +646,14 @@ class MainView(QWidget):
         self.empty_conversation_view = EmptyConversationView()
         self.view_layout.addWidget(self.empty_conversation_view)
 
-        # Add widgets to layout
         self.sources_pane_holder = QWidget()
         self.sources_pane_holder.setObjectName("MainView_sources_pane_holder")
-
-        self.sources_toolbar = SourceListToolbar()
         self.sources_pane_layout = QVBoxLayout()
         self.sources_pane_layout.setContentsMargins(0, 0, 0, 0)
+        self.sources_pane_layout.setSpacing(0)
         self.sources_pane_holder.setLayout(self.sources_pane_layout)
+
+        self.sources_toolbar = SourceListToolbar()
         self.sources_pane_layout.addWidget(self.sources_toolbar)
         self.sources_pane_layout.addWidget(self.source_list)
 
@@ -872,6 +872,17 @@ class EmptyConversationView(QWidget):
         self.no_source_selected.show()
 
 
+class SourceListToolbar(QToolBar):
+    def setup(self, controller: Controller):
+        self.setFixedHeight(30)
+        self.controller = controller
+        self.addAction(DeleteSourcesAction(self, self.controller, DeleteSourcesDialog))
+
+    def __init__(self):
+        super().__init__()
+        self.setObjectName("SourceListToolbar")
+
+
 class SourceListWidgetItem(QListWidgetItem):
     def __lt__(self, other: "SourceListWidgetItem") -> bool:
         """
@@ -887,16 +898,6 @@ class SourceListWidgetItem(QListWidgetItem):
             other_ts = arrow.get(them.last_updated)
             return my_ts < other_ts
         return True
-
-
-class SourceListToolbar(QToolBar):
-    def setup(self, controller: Controller):
-        self.controller = controller
-        self.addAction(DeleteSourcesAction(self, self.controller, DeleteSourcesDialog))
-
-    def __init__(self):
-        super().__init__()
-        self.setObjectName("SourceListToolbar")
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -43,8 +43,8 @@ from PyQt5.QtGui import (
 )
 from PyQt5.QtWidgets import (
     QAction,
-    QGridLayout,
     QCheckBox,
+    QGridLayout,
     QHBoxLayout,
     QLabel,
     QListWidget,
@@ -56,10 +56,10 @@ from PyQt5.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
     QStatusBar,
+    QToolBar,
     QToolButton,
     QVBoxLayout,
     QWidget,
-    QToolBar,
 )
 
 from securedrop_client import export, state
@@ -989,11 +989,11 @@ class SourceList(QListWidget):
             if source_widget.source_uuid in self.source_items:
                 del self.source_items[source_widget.source_uuid]
 
-            if source_widget.source_uuid in self.controller.checked_sources:
-                self.controller.uncheck_source(source_widget.source_uuid)
-
             deleted_uuids.append(source_widget.source_uuid)
             source_widget.deleteLater()
+
+        # We may need disable the delete multiple sources button
+        self.controller.maybe_toggle_delete_sources_button_enabled()
 
         # Update the remaining widgets
         for i in range(self.count()):
@@ -1346,7 +1346,7 @@ class SourceWidget(QWidget):
         self.checkbox.setObjectName("SourceWidget_checkbox")
         self.checkbox.setStyleSheet(self.SOURCE_CHECKBOX_CSS)
         self.checkbox.source_uuid = self.source.uuid
-        self.checkbox.toggled.connect(controller.toggle_source)
+        self.checkbox.toggled.connect(controller.maybe_toggle_delete_sources_button_enabled)
 
         self.timestamp = QLabel()
         self.timestamp.setSizePolicy(retain_space)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -780,6 +780,12 @@ class MainView(QWidget):
         self.view_layout.addWidget(widget)
         widget.show()
 
+    def toggle_delete_sources_button_enabled(self, enabled: bool) -> None:
+        """
+        Enable / disable the delete sources button.
+        """
+        self.sources_toolbar.delete_sources_action.setEnabled(enabled)
+
 
 class EmptyConversationView(QWidget):
 
@@ -876,7 +882,8 @@ class SourceListToolbar(QToolBar):
     def setup(self, controller: Controller):
         self.setFixedHeight(30)
         self.controller = controller
-        self.addAction(DeleteSourcesAction(self, self.controller, DeleteSourcesDialog))
+        self.delete_sources_action = DeleteSourcesAction(self, self.controller, DeleteSourcesDialog)
+        self.addAction(self.delete_sources_action)
 
     def __init__(self):
         super().__init__()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -647,6 +647,8 @@ class MainView(QWidget):
         self.view_layout.addWidget(self.empty_conversation_view)
 
         self.sources_pane_holder = QWidget()
+        # TODO - remove this hard-coded width
+        self.sources_pane_holder.setMaximumWidth(540)
         self.sources_pane_holder.setObjectName("MainView_sources_pane_holder")
         self.sources_pane_layout = QVBoxLayout()
         self.sources_pane_layout.setContentsMargins(0, 0, 0, 0)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -44,6 +44,7 @@ from PyQt5.QtGui import (
 from PyQt5.QtWidgets import (
     QAction,
     QGridLayout,
+    QCheckBox,
     QHBoxLayout,
     QLabel,
     QListWidget,
@@ -1303,6 +1304,10 @@ class SourceWidget(QWidget):
         self.paperclip_disabled.setSizePolicy(retain_space)
         self.paperclip_disabled.hide()
 
+        self.checkbox = QCheckBox()
+        self.checkbox.source_uuid = self.source.uuid
+        self.checkbox.toggled.connect(controller.toggle_source)
+
         self.timestamp = QLabel()
         self.timestamp.setSizePolicy(retain_space)
         self.timestamp.setFixedWidth(self.TIMESTAMP_WIDTH)
@@ -1310,13 +1315,13 @@ class SourceWidget(QWidget):
 
         # Create source_widget:
         # -------------------------------------------------------------------
-        # | ------ | -------- | ------                   | -----------      |
-        # | |star| | |spacer| | |name|                   | |paperclip|      |
-        # | ------ | -------- | ------                   | -----------      |
+        # | ---------- | -------- | ------               | -----------      |
+        # | |  star  | | |spacer| | |name|               | |paperclip|      |
+        # | ---------- | -------- | ------               | -----------      |
         # -------------------------------------------------------------------
-        # |        |          | ---------                | -----------      |
-        # |        |          | |preview|                | |timestamp|      |
-        # |        |          | ---------                | -----------      |
+        # | ---------- |          | ---------            | -----------      |
+        # | |checkbox| |          | |preview|            | |timestamp|      |
+        # | ---------- |          | ---------            | -----------      |
         # ------------------------------------------- -----------------------
         # Column 0, 1, and 3 are fixed. Column 2 stretches.
         self.source_widget = QWidget()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -980,6 +980,9 @@ class SourceList(QListWidget):
             if source_widget.source_uuid in self.source_items:
                 del self.source_items[source_widget.source_uuid]
 
+            if source_widget.source_uuid in self.controller.checked_sources:
+                self.controller.checked_sources.remove(source_widget.source_uuid)
+
             deleted_uuids.append(source_widget.source_uuid)
             source_widget.deleteLater()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -59,6 +59,7 @@ from PyQt5.QtWidgets import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    QToolBar,
 )
 
 from securedrop_client import export, state
@@ -75,11 +76,13 @@ from securedrop_client.gui import conversation
 from securedrop_client.gui.actions import (
     DeleteConversationAction,
     DeleteSourceAction,
+    DeleteSourcesAction,
     DownloadConversation,
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
 from securedrop_client.gui.source import DeleteSourceDialog
+from securedrop_client.gui.source.delete.dialog import DeleteSourcesDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.storage import source_exists
@@ -644,7 +647,17 @@ class MainView(QWidget):
         self.view_layout.addWidget(self.empty_conversation_view)
 
         # Add widgets to layout
-        self._layout.addWidget(self.source_list, stretch=1)
+        self.sources_pane_holder = QWidget()
+        self.sources_pane_holder.setObjectName("MainView_sources_pane_holder")
+
+        self.sources_toolbar = SourceListToolbar()
+        self.sources_pane_layout = QVBoxLayout()
+        self.sources_pane_layout.setContentsMargins(0, 0, 0, 0)
+        self.sources_pane_holder.setLayout(self.sources_pane_layout)
+        self.sources_pane_layout.addWidget(self.sources_toolbar)
+        self.sources_pane_layout.addWidget(self.source_list)
+
+        self._layout.addWidget(self.sources_pane_holder, stretch=1)
         self._layout.addWidget(self.view_holder, stretch=2)
 
         # Note: We should not delete SourceConversationWrapper when its source is unselected. This
@@ -657,6 +670,7 @@ class MainView(QWidget):
         """
         self.controller = controller
         self.source_list.setup(controller)
+        self.sources_toolbar.setup(controller)
 
     def show_sources(self, sources: List[Source]) -> None:
         """
@@ -873,6 +887,16 @@ class SourceListWidgetItem(QListWidgetItem):
             other_ts = arrow.get(them.last_updated)
             return my_ts < other_ts
         return True
+
+
+class SourceListToolbar(QToolBar):
+    def setup(self, controller: Controller):
+        self.controller = controller
+        self.addAction(DeleteSourcesAction(self, self.controller, DeleteSourcesDialog))
+
+    def __init__(self):
+        super().__init__()
+        self.setObjectName("SourceListToolbar")
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1281,6 +1281,7 @@ class SourceWidget(QWidget):
     SOURCE_NAME_CSS = load_css("source_name.css")
     SOURCE_PREVIEW_CSS = load_css("source_preview.css")
     SOURCE_TIMESTAMP_CSS = load_css("source_timestamp.css")
+    SOURCE_CHECKBOX_CSS = load_css("source_checkbox.css")
 
     CONVERSATION_DELETED_TEXT = _("\u2014 All files and messages deleted for this source \u2014")
 
@@ -1342,6 +1343,8 @@ class SourceWidget(QWidget):
         self.paperclip_disabled.hide()
 
         self.checkbox = QCheckBox()
+        self.checkbox.setObjectName("SourceWidget_checkbox")
+        self.checkbox.setStyleSheet(self.SOURCE_CHECKBOX_CSS)
         self.checkbox.source_uuid = self.source.uuid
         self.checkbox.toggled.connect(controller.toggle_source)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -988,7 +988,7 @@ class SourceList(QListWidget):
                 del self.source_items[source_widget.source_uuid]
 
             if source_widget.source_uuid in self.controller.checked_sources:
-                self.controller.checked_sources.remove(source_widget.source_uuid)
+                self.controller.uncheck_source(source_widget.source_uuid)
 
             deleted_uuids.append(source_widget.source_uuid)
             source_widget.deleteLater()

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -82,6 +82,9 @@ msgstr ""
 msgid "Delete Source Account"
 msgstr ""
 
+msgid "Delete Multiple Source Accounts"
+msgstr ""
+
 msgid "Delete All Files and Messages"
 msgstr ""
 
@@ -328,5 +331,17 @@ msgid "Your organization will not be able to send them replies."
 msgstr ""
 
 msgid "All files and messages from that source will also be destroyed."
+msgstr ""
+
+msgid "YES, DELETE ALL SOURCE ACCOUNT"
+msgstr ""
+
+msgid "When the entire account for all source are deleted:"
+msgstr ""
+
+msgid "The sources will not be able to log in with their codename again."
+msgstr ""
+
+msgid "All files and messages from the sources will also be destroyed."
 msgstr ""
 

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Delete Source Account"
 msgstr ""
 
-msgid "Delete Multiple Source Accounts"
+msgid "Delete Source Accounts"
 msgstr ""
 
 msgid "Delete All Files and Messages"
@@ -333,10 +333,10 @@ msgstr ""
 msgid "All files and messages from that source will also be destroyed."
 msgstr ""
 
-msgid "YES, DELETE ALL SOURCE ACCOUNT"
+msgid "YES, DELETE THESE SOURCE ACCOUNTS"
 msgstr ""
 
-msgid "When the entire account for all source are deleted:"
+msgid "When the entire accounts for these sources are deleted:"
 msgstr ""
 
 msgid "The sources will not be able to log in with their codename again."

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -428,8 +428,15 @@ class Controller(QObject):
         else:
             self.checked_sources.remove(checkbox.source_uuid)
 
-        self.gui.toggle_delete_sources_button_enabled(len(self.checked_sources) > 0)
+        self._toggle_delete_source_button_enabled()
         print(f"CHECKED sourced:  " + str(self.checked_sources))
+
+    def uncheck_source(self, source_uuid: str):
+        self.checked_sources.remove(source_uuid)
+        self._toggle_delete_source_button_enabled()
+
+    def _toggle_delete_source_button_enabled(self):
+        self.gui.toggle_delete_sources_button_enabled(len(self.checked_sources) > 0)
 
     @pyqtSlot(int)
     def _on_main_queue_updated(self, num_items: int) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -429,7 +429,6 @@ class Controller(QObject):
             self.checked_sources.remove(checkbox.source_uuid)
 
         self._toggle_delete_source_button_enabled()
-        print(f"CHECKED sourced:  " + str(self.checked_sources))
 
     def uncheck_source(self, source_uuid: str):
         self.checked_sources.remove(source_uuid)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -427,6 +427,8 @@ class Controller(QObject):
             self.checked_sources.add(checkbox.source_uuid)
         else:
             self.checked_sources.remove(checkbox.source_uuid)
+
+        self.gui.toggle_delete_sources_button_enabled(len(self.checked_sources) > 0)
         print(f"CHECKED sourced:  " + str(self.checked_sources))
 
     @pyqtSlot(int)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -24,7 +24,7 @@ import uuid
 from datetime import datetime
 from gettext import gettext as _
 from gettext import ngettext
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Set, Type, Union
 
 import arrow
 import sdclientapi
@@ -395,6 +395,9 @@ class Controller(QObject):
         # File data.
         self.data_dir = os.path.join(self.home, "data")
 
+        # uuids of sources with checkboxes checked
+        self.checked_sources: Set[str] = set()
+
         # Background sync to keep client up-to-date with server changes
         self.api_sync = ApiSync(
             self.api, self.session_maker, self.gpg, self.data_dir, self.sync_thread, state
@@ -417,6 +420,14 @@ class Controller(QObject):
             and oct(os.stat(self.last_sync_filepath).st_mode) != "0o100600"
         ):
             os.chmod(self.last_sync_filepath, 0o600)
+
+    def toggle_source(self):
+        checkbox = self.sender()
+        if checkbox.isChecked():
+            self.checked_sources.add(checkbox.source_uuid)
+        else:
+            self.checked_sources.remove(checkbox.source_uuid)
+        print(f"CHECKED sourced:  " + str(self.checked_sources))
 
     @pyqtSlot(int)
     def _on_main_queue_updated(self, num_items: int) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1049,6 +1049,24 @@ class Controller(QObject):
         self.source_deleted.emit(source.uuid)
 
     @login_required
+    def delete_sources(self, sources: List[str]) -> None:
+        """
+        Performs a delete operation on multiple source records.
+
+        This method will submit a job per source to delete the source record on
+        the server. If the job succeeds, the success handler will
+        synchronize the server records with the local state. If not,
+        the failure handler will display an error.
+        """
+        for source_uuid in sources:
+            job = DeleteSourceJob(source_uuid)
+            job.success_signal.connect(self.on_delete_source_success)
+            job.failure_signal.connect(self.on_delete_source_failure)
+
+            self.add_job.emit(job)
+            self.source_deleted.emit(source_uuid)
+
+    @login_required
     def delete_conversation(self, source: db.Source) -> None:
         """
         Deletes the content of a source conversation.

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -430,7 +430,6 @@ class Controller(QObject):
             checkbox = source_item_widget.findChild(QCheckBox)
             if checkbox.isChecked():
                 checked_source_uuids.append(source_uuid)
-        print("checked sources: ", checked_source_uuids)
         return checked_source_uuids
 
     def maybe_toggle_delete_sources_button_enabled(self):
@@ -1065,7 +1064,6 @@ class Controller(QObject):
         synchronize the server records with the local state. If not,
         the failure handler will display an error.
         """
-        print(f"sources: {sources}")
         for source_uuid in sources:
             job = DeleteSourceJob(source_uuid)
             job.success_signal.connect(self.on_delete_source_success)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1071,7 +1071,7 @@ class Controller(QObject):
             job = DeleteSourceJob(source_uuid)
             job.success_signal.connect(self.on_delete_source_success)
             job.failure_signal.connect(self.on_delete_source_failure)
-            self.checked_sources.remove(source_uuid)
+            self.uncheck_source(source_uuid)
 
             self.add_job.emit(job)
             self.source_deleted.emit(source_uuid)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -30,6 +30,7 @@ import arrow
 import sdclientapi
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QObject, QProcess, QThread, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtWidgets import QCheckBox
 from sdclientapi import AuthError, RequestTimeoutError, ServerConnectionError
 from sqlalchemy.orm.session import sessionmaker
 
@@ -395,9 +396,6 @@ class Controller(QObject):
         # File data.
         self.data_dir = os.path.join(self.home, "data")
 
-        # uuids of sources with checkboxes checked
-        self.checked_sources: Set[str] = set()
-
         # Background sync to keep client up-to-date with server changes
         self.api_sync = ApiSync(
             self.api, self.session_maker, self.gpg, self.data_dir, self.sync_thread, state
@@ -421,21 +419,22 @@ class Controller(QObject):
         ):
             os.chmod(self.last_sync_filepath, 0o600)
 
-    def toggle_source(self):
-        checkbox = self.sender()
-        if checkbox.isChecked():
-            self.checked_sources.add(checkbox.source_uuid)
-        else:
-            self.checked_sources.remove(checkbox.source_uuid)
+    def get_checked_sources(self) -> List[str]:
+        """
+        Returns the list of sources that are checked in the UI.
+        """
+        source_items = self.gui.main_view.source_list.source_items
+        checked_source_uuids = []
+        for source_uuid, source_item in source_items.items():
+            source_item_widget = self.gui.main_view.source_list.itemWidget(source_item)
+            checkbox = source_item_widget.findChild(QCheckBox)
+            if checkbox.isChecked():
+                checked_source_uuids.append(source_uuid)
+        print("checked sources: ", checked_source_uuids)
+        return checked_source_uuids
 
-        self._toggle_delete_source_button_enabled()
-
-    def uncheck_source(self, source_uuid: str):
-        self.checked_sources.remove(source_uuid)
-        self._toggle_delete_source_button_enabled()
-
-    def _toggle_delete_source_button_enabled(self):
-        self.gui.toggle_delete_sources_button_enabled(len(self.checked_sources) > 0)
+    def maybe_toggle_delete_sources_button_enabled(self):
+        self.gui.toggle_delete_sources_button_enabled(len(self.get_checked_sources()) > 0)
 
     @pyqtSlot(int)
     def _on_main_queue_updated(self, num_items: int) -> None:
@@ -1066,11 +1065,11 @@ class Controller(QObject):
         synchronize the server records with the local state. If not,
         the failure handler will display an error.
         """
+        print(f"sources: {sources}")
         for source_uuid in sources:
             job = DeleteSourceJob(source_uuid)
             job.success_signal.connect(self.on_delete_source_success)
             job.failure_signal.connect(self.on_delete_source_failure)
-            self.uncheck_source(source_uuid)
 
             self.add_job.emit(job)
             self.source_deleted.emit(source_uuid)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1062,6 +1062,7 @@ class Controller(QObject):
             job = DeleteSourceJob(source_uuid)
             job.success_signal.connect(self.on_delete_source_success)
             job.failure_signal.connect(self.on_delete_source_failure)
+            self.checked_sources.remove(source_uuid)
 
             self.add_job.emit(job)
             self.source_deleted.emit(source_uuid)

--- a/securedrop_client/resources/css/source_checkbox.css
+++ b/securedrop_client/resources/css/source_checkbox.css
@@ -1,0 +1,3 @@
+#SourceWidget_checkbox {
+    margin-left: 3px;
+}

--- a/tests/functional/test_delete_sources.py
+++ b/tests/functional/test_delete_sources.py
@@ -16,6 +16,9 @@ def test_delete_sources(functional_test_logged_in_context, qtbot, mocker):
     """
     gui, controller = functional_test_logged_in_context
 
+    # no sources checked so delete button is disabled
+    assert not gui.main_view.sources_toolbar.delete_sources_action.isEnabled()
+
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_items.keys())) >= 2
 
@@ -33,6 +36,9 @@ def test_delete_sources(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_CLICK_ACTION)
     qtbot.wait(TIME_CLICK_ACTION)
 
+    # two sources checked so delete button is enabled
+    assert gui.main_view.sources_toolbar.delete_sources_action.isEnabled()
+
     # Delete the selected sources
     # Note: The qtbot object cannot interact with QAction items (as used in the delete button/menu)
     # so we programatically delete the source rather than using the GUI via qtbot
@@ -44,3 +50,6 @@ def test_delete_sources(functional_test_logged_in_context, qtbot, mocker):
         assert gui.main_view.source_list.count() == source_count - 2
 
     qtbot.waitUntil(check_source_list, timeout=TIME_RENDER_SOURCE_LIST)
+
+    # checked sources removed so delete button is disabled
+    assert not gui.main_view.sources_toolbar.delete_sources_action.isEnabled()

--- a/tests/functional/test_delete_sources.py
+++ b/tests/functional/test_delete_sources.py
@@ -3,10 +3,9 @@ Functional tests for deleting multiple sources in the SecureDrop client.
 """
 import pytest
 from flaky import flaky
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox
 
-from tests.conftest import TIME_CLICK_ACTION, TIME_RENDER_CONV_VIEW, TIME_RENDER_SOURCE_LIST
+from tests.conftest import TIME_CLICK_ACTION, TIME_RENDER_SOURCE_LIST
 
 
 @flaky

--- a/tests/functional/test_delete_sources.py
+++ b/tests/functional/test_delete_sources.py
@@ -1,0 +1,47 @@
+"""
+Functional tests for deleting multiple sources in the SecureDrop client.
+"""
+import pytest
+from flaky import flaky
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QCheckBox
+
+from tests.conftest import TIME_CLICK_ACTION, TIME_RENDER_CONV_VIEW, TIME_RENDER_SOURCE_LIST
+
+
+@flaky
+@pytest.mark.vcr()
+def test_delete_sources(functional_test_logged_in_context, qtbot, mocker):
+    """
+    Verify that the source list's size is reduced by two when two sources are deleted.
+    """
+    gui, controller = functional_test_logged_in_context
+
+    def check_for_sources():
+        assert len(list(gui.main_view.source_list.source_items.keys())) >= 2
+
+    # Select the first two sources in the source list
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
+    source_ids = list(gui.main_view.source_list.source_items.keys())
+    first_source_item = gui.main_view.source_list.source_items[source_ids[-2]]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
+    first_source_widget_checkbox = first_source_widget.findChild(QCheckBox)
+    first_source_widget_checkbox.click()
+    second_source_item = gui.main_view.source_list.source_items[source_ids[-1]]
+    second_source_widget = gui.main_view.source_list.itemWidget(second_source_item)
+    second_source_widget_checkbox = second_source_widget.findChild(QCheckBox)
+    second_source_widget_checkbox.click()
+    qtbot.wait(TIME_CLICK_ACTION)
+    qtbot.wait(TIME_CLICK_ACTION)
+
+    # Delete the selected sources
+    # Note: The qtbot object cannot interact with QAction items (as used in the delete button/menu)
+    # so we programatically delete the source rather than using the GUI via qtbot
+    source_count = gui.main_view.source_list.count()
+    sources_to_delete = [first_source_widget.source.uuid, second_source_widget.source.uuid]
+    controller.delete_sources(sources_to_delete)
+
+    def check_source_list():
+        assert gui.main_view.source_list.count() == source_count - 2
+
+    qtbot.waitUntil(check_source_list, timeout=TIME_RENDER_SOURCE_LIST)


### PR DESCRIPTION
# Description
Fixes #1569

- Add a checkbox to each source widget in the source list.
- Add a toolbar to the top of the source list with a button to delete all source accounts that are checked. The button is disabled by default and enabled whenever one or more sources is checked.
- Batch deletion of source accounts works similarly to deleting individual source accounts; clicking "Delete source accounts" opens a dialogue so that the user can confirm that they'd like to delete multiple source accounts. When they confirm, a DeleteSourceJob is added for each checked source widget. Users need to be signed in in order to delete multiple source accounts.

https://user-images.githubusercontent.com/17057932/217248635-96d579ea-2693-4491-906f-0783a16382f0.mov

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
