### PR TITLE
Use locale when formatting dates. Pull locale logic into separate file. 

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import gettext
-import locale
 import logging
 import os
 import platform
@@ -29,7 +28,7 @@ from contextlib import contextmanager
 from gettext import gettext as _
 from logging.handlers import SysLogHandler, TimedRotatingFileHandler
 from pathlib import Path
-from typing import Any, NewType, NoReturn
+from typing import Any, NoReturn
 
 from PyQt5.QtCore import Qt, QThread, QTimer
 from PyQt5.QtWidgets import QApplication, QMessageBox
@@ -41,9 +40,6 @@ from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.utils import safe_mkdir
 
-LanguageCode = NewType("LanguageCode", str)
-
-DEFAULT_LANGUAGE = LanguageCode("en")
 DEFAULT_SDC_HOME = "~/.securedrop_client"
 DESKTOP_FILE_NAME = "press.freedom.SecureDropClient.desktop"
 ENCODING = "utf-8"
@@ -68,22 +64,11 @@ def excepthook(*exc_args):  # type: ignore [no-untyped-def]
     sys.exit(1)
 
 
-def configure_locale_and_language() -> LanguageCode:
+def configure_locale_and_language() -> None:
     """Configure locale, language and define location of translation assets."""
     localedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "locale"))
-    try:
-        # Use the operating system's locale.
-        current_locale, encoding = locale.getdefaultlocale()
-        # Get the language code.
-        if current_locale is None:
-            code = DEFAULT_LANGUAGE
-        else:
-            code = LanguageCode(current_locale[:2])
-    except ValueError:  # pragma: no cover
-        code = DEFAULT_LANGUAGE  # pragma: no cover
     gettext.bindtextdomain(GETTEXT_DOMAIN, localedir=localedir)
     gettext.textdomain(GETTEXT_DOMAIN)
-    return code
 
 
 def configure_logging(sdc_home: Path) -> None:

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -1,0 +1,31 @@
+"""
+Helper functions for formatting information in the UI
+
+"""
+import datetime
+
+import arrow
+from dateutil import tz
+from PyQt5.QtCore import QTimeZone
+
+
+def format_datetime_month_day(date: datetime.datetime) -> str:
+    """
+    Formats date as e.g. Sep 16
+    """
+    return arrow.get(date).format("MMM D")
+
+
+def localise_datetime(date: datetime.datetime) -> datetime.datetime:
+    """
+    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    """
+    local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
+    return arrow.get(date).to(tz.gettz(local_timezone)).datetime
+
+
+def format_datetime_local(date: datetime.datetime) -> str:
+    """
+    Localise date and return as a string in the format e.g. Sep 16
+    """
+    return format_datetime_month_day(localise_datetime(date))

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -18,7 +18,7 @@ def format_datetime_month_day(date: datetime.datetime) -> str:
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     """
-    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    Localise the datetime object to system timezone
     """
     local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
     return arrow.get(date).to(tz.gettz(local_timezone)).datetime

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -8,12 +8,14 @@ import arrow
 from dateutil import tz
 from PyQt5.QtCore import QTimeZone
 
+from securedrop_client.locale import get_locale
+
 
 def format_datetime_month_day(date: datetime.datetime) -> str:
     """
-    Formats date as e.g. Sep 16
+    Formats date as e.g. Sep 16 in the current locale
     """
-    return arrow.get(date).format("MMM D")
+    return arrow.get(date).format("MMM D", locale=get_locale())
 
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -78,6 +78,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
@@ -1330,7 +1331,7 @@ class SourceWidget(QWidget):
         try:
             self.controller.session.refresh(self.source)
             self.last_updated = self.source.last_updated
-            self.timestamp.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+            self.timestamp.setText(_(format_datetime_local(self.source.last_updated)))
             self.name.setText(self.source.journalist_designation)
 
             self.set_snippet(self.source_uuid)
@@ -3482,7 +3483,7 @@ class SourceProfileShortWidget(QWidget):
             self.MARGIN_LEFT, self.VERTICAL_MARGIN, self.MARGIN_RIGHT, self.VERTICAL_MARGIN
         )
         title = TitleLabel(self.source.journalist_designation)
-        self.updated = LastUpdatedLabel(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated = LastUpdatedLabel(_(format_datetime_local(self.source.last_updated)))
         menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
@@ -3503,4 +3504,4 @@ class SourceProfileShortWidget(QWidget):
         Ensure the timestamp is always kept up to date with the latest activity
         from the source.
         """
-        self.updated.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated.setText(_(format_datetime_local(self.source.last_updated)))

--- a/securedrop_client/locale.py
+++ b/securedrop_client/locale.py
@@ -1,0 +1,25 @@
+import locale
+from typing import NewType
+
+LanguageCode = NewType("LanguageCode", str)
+DEFAULT_LANGUAGE = LanguageCode("en")
+DEFAULT_LOCALE = "en_US"
+
+
+def get_locale():
+    """Get the current locale."""
+    try:
+        # Use the operating system's locale.
+        current_locale, encoding = locale.getdefaultlocale()
+        # Get the language code.
+        if current_locale is None:
+            return DEFAULT_LOCALE
+    except ValueError:  # pragma: no cover
+        return DEFAULT_LOCALE
+    return current_locale
+
+
+def get_locale_code() -> LanguageCode:
+    """Get the current locale code."""
+    current_locale = get_locale()
+    return LanguageCode(current_locale[:2])

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,0 +1,11 @@
+import datetime
+
+from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+
+
+def test_format_datetime_month_day():
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
+    # this test is a reminder to check both views!
+    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+    assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -3,9 +3,12 @@ import datetime
 from securedrop_client.gui.datetime_helpers import format_datetime_month_day
 
 
-def test_format_datetime_month_day():
+def test_format_datetime_month_day(mocker):
     # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
     # this test is a reminder to check both views!
-    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    midnight_january_london = datetime.datetime(2023, 2, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
-    assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+    assert format_datetime_month_day(midnight_january_london) == "Feb 1"
+
+    mocker.patch("locale.getdefaultlocale", return_value=('fr_FR', None))
+    assert format_datetime_month_day(midnight_january_london) == "févr 1"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from gettext import gettext as _
 from unittest.mock import Mock, PropertyMock
 
-import arrow
 import sqlalchemy
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
@@ -18,6 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
+from securedrop_client.gui.format_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
@@ -3749,7 +3749,7 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
 
     scw.conversation_view.add_file(file=file, index=1)
 
-    expected_timestamp = arrow.get(source.last_updated).format("MMM D")
+    expected_timestamp = format_datetime_local(source.last_updated)
 
     def check_timestamp():
         assert scw.conversation_title_bar.updated.text() == expected_timestamp
@@ -5223,9 +5223,7 @@ def test_SourceProfileShortWidget_update_timestamp(mocker):
     spsw = SourceProfileShortWidget(mock_source, mock_controller, None)
     spsw.updated = mocker.MagicMock()
     spsw.update_timestamp()
-    spsw.updated.setText.assert_called_once_with(
-        arrow.get(mock_source.last_updated).format("MMM D")
-    )
+    spsw.updated.setText.assert_called_once_with(format_datetime_local(mock_source.last_updated))
 
 
 def test_SenderIcon_for_deleted_user(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
-from securedrop_client.gui.format_helpers import format_datetime_local
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,12 +23,6 @@ from securedrop_client.app import (
 from tests.helper import app  # noqa: F401
 
 
-def test_application_sets_en_as_default_language_code(mocker):
-    mocker.patch("locale.getdefaultlocale", return_value=(None, None))
-    language_code = configure_locale_and_language()
-    assert language_code == "en"
-
-
 @pytest.mark.parametrize("lang", ["es"], indirect=True)
 def test_application_uses_set_locale(mocker, lang):
     """

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,0 +1,13 @@
+"""
+Tests for the app module, which sets things up and runs the application.
+"""
+
+from tests.helper import app  # noqa: F401
+from securedrop_client.locale import get_locale_code
+
+
+def test_application_sets_en_as_default_language_code(mocker):
+    mocker.patch("locale.getdefaultlocale", return_value=(None, None))
+    language_code = get_locale_code()
+    assert language_code == "en"
+


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1536

This change aims to localise dates shown in the UI. In the original issue @eloquence suggested mapping the locale based off securedrop-client's supported locales. I'm happy to try do this, though couldn't find any code related to this in securedrop-client. I think this solution - which just uses the value from the [locale](https://docs.python.org/3/library/locale.html) library - might be a good (lazier) solution.

# Test Plan
This still needs testing on qubes - I need to work out how to modify the locale for sd-app

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
