### PR TITLE
When formatting dates, use system locale

### DIFF
--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -1,0 +1,31 @@
+"""
+Helper functions for formatting information in the UI
+
+"""
+import datetime
+
+import arrow
+from dateutil import tz
+from PyQt5.QtCore import QTimeZone
+
+
+def format_datetime_month_day(date: datetime.datetime) -> str:
+    """
+    Formats date as e.g. Sep 16
+    """
+    return arrow.get(date).format("MMM D")
+
+
+def localise_datetime(date: datetime.datetime) -> datetime.datetime:
+    """
+    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    """
+    local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
+    return arrow.get(date).to(tz.gettz(local_timezone)).datetime
+
+
+def format_datetime_local(date: datetime.datetime) -> str:
+    """
+    Localise date and return as a string in the format e.g. Sep 16
+    """
+    return format_datetime_month_day(localise_datetime(date))

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -18,7 +18,7 @@ def format_datetime_month_day(date: datetime.datetime) -> str:
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     """
-    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    Localise the datetime object to system timezone
     """
     local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
     return arrow.get(date).to(tz.gettz(local_timezone)).datetime

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -6,14 +6,14 @@ import datetime
 
 import arrow
 from dateutil import tz
-from PyQt5.QtCore import QTimeZone
+from PyQt5.QtCore import QLocale, QTimeZone
 
 
 def format_datetime_month_day(date: datetime.datetime) -> str:
     """
-    Formats date as e.g. Sep 16
+    Formats date as e.g. Sep 16 in the current locale
     """
-    return arrow.get(date).format("MMM D")
+    return arrow.get(date).format("MMM D", locale=QLocale().name())
 
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -80,6 +80,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
@@ -1330,7 +1331,7 @@ class SourceWidget(QWidget):
         try:
             self.controller.session.refresh(self.source)
             self.last_updated = self.source.last_updated
-            self.timestamp.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+            self.timestamp.setText(_(format_datetime_local(self.source.last_updated)))
             self.name.setText(self.source.journalist_designation)
 
             self.set_snippet(self.source_uuid)
@@ -3481,7 +3482,7 @@ class SourceProfileShortWidget(QWidget):
             self.MARGIN_LEFT, self.VERTICAL_MARGIN, self.MARGIN_RIGHT, self.VERTICAL_MARGIN
         )
         title = TitleLabel(self.source.journalist_designation)
-        self.updated = LastUpdatedLabel(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated = LastUpdatedLabel(_(format_datetime_local(self.source.last_updated)))
         menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
@@ -3502,4 +3503,4 @@ class SourceProfileShortWidget(QWidget):
         Ensure the timestamp is always kept up to date with the latest activity
         from the source.
         """
-        self.updated.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated.setText(_(format_datetime_local(self.source.last_updated)))

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,11 +1,34 @@
 import datetime
+from dateutil import tz
 
-from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+from PyQt5.QtCore import QByteArray
+
+from securedrop_client.gui.datetime_helpers import (
+    localise_datetime,
+    format_datetime_local,
+    format_datetime_month_day
+)
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
-    # issues - this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format
+    # may result in UI issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+
+
+def test_localise_datetime(mocker):
+    mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+                 return_value=QByteArray(b"Pacific/Auckland"))
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    morning_january_2_auckland = datetime.datetime(2023, 1, 2, 7, 0, 0,
+                                                   tzinfo=tz.gettz("Pacific/Auckland"))
+    assert localise_datetime(evening_january_1_london) == morning_january_2_auckland
+
+
+def test_format_datetime_local(mocker):
+    mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+                 return_value=QByteArray(b"Pacific/Auckland"))
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    assert format_datetime_local(evening_january_1_london) == "Jan 2"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,0 +1,11 @@
+import datetime
+
+from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+
+
+def test_format_datetime_month_day():
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
+    # this test is a reminder to check both views!
+    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+    assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -4,8 +4,8 @@ from securedrop_client.gui.datetime_helpers import format_datetime_month_day
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
-    # this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
+    # issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -10,12 +10,13 @@ from securedrop_client.gui.datetime_helpers import (
 )
 
 
-def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format
-    # may result in UI issues - this test is a reminder to check both views!
-    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+def test_format_datetime_month_day(mocker):
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
+    # issues - this test is a reminder to check both views!
+    mocker.patch("PyQt5.QtCore.QLocale.name", return_value="fr_FR")
+    midnight_january_london = datetime.datetime(2023, 2, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
-    assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+    assert format_datetime_month_day(midnight_january_london) == "févr 1"
 
 
 def test_localise_datetime(mocker):
@@ -32,3 +33,4 @@ def test_format_datetime_local(mocker):
                  return_value=QByteArray(b"Pacific/Auckland"))
     evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
     assert format_datetime_local(evening_january_1_london) == "Jan 2"
+

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from gettext import gettext as _
 from unittest.mock import Mock, PropertyMock
 
-import arrow
 import sqlalchemy
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
@@ -18,6 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
+from securedrop_client.gui.format_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
@@ -3749,7 +3749,7 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
 
     scw.conversation_view.add_file(file=file, index=1)
 
-    expected_timestamp = arrow.get(source.last_updated).format("MMM D")
+    expected_timestamp = format_datetime_local(source.last_updated)
 
     def check_timestamp():
         assert scw.conversation_title_bar.updated.text() == expected_timestamp
@@ -5223,9 +5223,7 @@ def test_SourceProfileShortWidget_update_timestamp(mocker):
     spsw = SourceProfileShortWidget(mock_source, mock_controller, None)
     spsw.updated = mocker.MagicMock()
     spsw.update_timestamp()
-    spsw.updated.setText.assert_called_once_with(
-        arrow.get(mock_source.last_updated).format("MMM D")
-    )
+    spsw.updated.setText.assert_called_once_with(format_datetime_local(mock_source.last_updated))
 
 
 def test_SenderIcon_for_deleted_user(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
-from securedrop_client.gui.format_helpers import format_datetime_local
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1536 - localises dates to the system locale.

Depends on https://github.com/freedomofpress/securedrop-client/pull/1626

This doesn't map towards the currently supported locales in securedrop-client as suggested in https://github.com/freedomofpress/securedrop-client/issues/1536 - it just uses the system locale and relies on the `arrow` library. This seems a good first step. 

# Test Plan
I've tested this on my mac and qubes workstation by setting the environment variable LANG=ru_RU:

<img width="1489" alt="Screenshot 2023-02-15 at 10 23 57" src="https://user-images.githubusercontent.com/3606555/219001302-1e7bb7fb-d064-4577-869d-8ce39fed50ed.png">


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
