### PR TITLE
Fix circular dependency error

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -26,7 +26,6 @@ from securedrop_client.gui.conversation import (
     PrintTranscriptDialog as PrintConversationTranscriptDialog,
 )
 from securedrop_client.gui.conversation.export.whistleflow_dialog import WhistleflowDialog
-from securedrop_client.gui.widgets import SourceListToolbar
 from securedrop_client.logic import Controller
 from securedrop_client.utils import safe_mkdir
 
@@ -112,7 +111,7 @@ class DeleteSourcesAction(QAction):
 
     def __init__(
         self,
-        parent: SourceListToolbar,
+        parent: 'SourceListToolbar',
         controller: Controller,
         confirmation_dialog: Callable[[List[str]], QDialog],
     ) -> None:


### PR DESCRIPTION
# Description
Currently when I run `main` I get this error:

`ImportError: cannot import name 'SourceListToolbar' from partially initialized module 'securedrop_client.gui.widgets' (most likely due to a circular import) (/Users/philip_mcmahon/code/securedrop-client/securedrop_client/gui/widgets.py)`

This resolves that by using a [forward reference](https://peps.python.org/pep-0484/#forward-references) - using a string literal as the type hint