### PR TITLE
Include source id in transcript filename

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -71,7 +71,7 @@ class Export(QObject):
     DISK_ENCRYPTION_KEY_NAME = "encryption_key"
     DISK_EXPORT_DIR = "export_data"
 
-    WHISTLEFLOW_METADATA = {"device": "whistleflow-view"}
+    WHISTLEFLOW_METADATA = {}
 
     # Set up signals for communication with the controller
     preflight_check_call_failure = pyqtSignal(object)
@@ -237,7 +237,8 @@ class Export(QObject):
         archive_path = os.path.join(archive_dir, archive_fn)
 
         with tarfile.open(archive_path, "w:gz") as archive:
-            cls._add_virtual_file_to_archive(archive, cls.METADATA_FN, metadata)
+            if metadata:
+                cls._add_virtual_file_to_archive(archive, cls.METADATA_FN, metadata)
 
             # When more than one file is added to the archive,
             # extra care must be taken to prevent name collisions.
@@ -280,14 +281,14 @@ class Export(QObject):
         """
         filename = os.path.basename(filepath)
         arcname = os.path.join(cls.DISK_EXPORT_DIR, filename)
+
         if prevent_name_collisions:
             (parent_path, _) = os.path.split(filepath)
             grand_parent_path, parent_name = os.path.split(parent_path)
             grand_parent_name = os.path.split(grand_parent_path)[1]
-            arcname = os.path.join("export_data", grand_parent_name, parent_name, filename)
-            if filename == "transcript.txt":
-                arcname = os.path.join("export_data", parent_name, filename)
-
+            arcname = os.path.join(cls.DISK_EXPORT_DIR, grand_parent_name, parent_name, filename)
+            if filename.endswith("transcript.txt"):
+                arcname = os.path.join(cls.DISK_EXPORT_DIR, parent_name, filename)
         archive.add(filepath, arcname=arcname, recursive=False)
 
     def _run_printer_preflight(self, archive_dir: str) -> None:

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -259,10 +259,11 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         (Re-)generates the conversation transcript and opens a confirmation dialog to export it,
         in the manner of the existing ExportFileDialog.
         """
+        transcript_filename = _("{}_transcript.txt").format(self._source.journalist_filename)
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
-            .joinpath("transcript.txt")
+            .joinpath(transcript_filename)
         )
 
         transcript = ConversationTranscript(self._source)
@@ -280,13 +281,13 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         with open(file_path, "r") as f:
             if self._destination == ExportDestination.USB:
                 dialog = ExportConversationTranscriptDialog(
-                    self._export_device, "transcript.txt", str(file_path)
+                    self._export_device, transcript_filename, str(file_path)
                 )
                 dialog.exec()
             else:
                 whistleflow_dialog = WhistleflowDialog(
                     self._export_device,
-                    "transcript.txt",
+                    transcript_filename,
                     [str(file_path)],
                 )
                 whistleflow_dialog.exec()
@@ -356,10 +357,11 @@ class ExportConversationAction(QAction):  # pragma: nocover
         alongside all the (attached) files that are downloaded, in the manner
         of the existing ExportFileDialog.
         """
+        transcript_filename = _("{}_transcript.txt").format(self._source.journalist_filename)
         transcript_location = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
-            .joinpath("transcript.txt")
+            .joinpath(transcript_filename)
         )
 
         transcript = ConversationTranscript(self._source)
@@ -389,7 +391,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
 
             file_count = len(files)
             if file_count == 1:
-                summary = "transcript.txt"
+                summary = transcript_filename
             else:
                 summary = _("all files and transcript")
 

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.11.0\n"
 
 msgid "{application_name} is already running"
 msgstr ""
@@ -95,6 +95,9 @@ msgid "Export Transcript to USB"
 msgstr ""
 
 msgid "Export Transcript to Whistleflow View"
+msgstr ""
+
+msgid "{}_transcript.txt"
 msgstr ""
 
 msgid "Export All to USB"


### PR DESCRIPTION
# Description
This change includes the source reference in the transcript file name when exporting - so e.g. `source_reference-transcript.txt`

Also, don't include metadata file for whistleflow exports
