### PR TITLE
Put whistleflow exports in directory called source_name

### DIFF
--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop Client 102.9.0\n"
+"Project-Id-Version: SecureDrop Client 104.9.0\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
# Description
The form to send exports from whistleflow-view to Giant introduced in https://github.com/guardian/whistleflow/pull/42 relies on directory structure to infer the source's name and pre-populate the form.
At the moment, exports of just transcripts (and exports of entire conversations that don't happen to have downloaded attachments) are exported as a tar file containing `export_data/transcript.txt`.
After the change, when exporting the transcript of a conversation with a source called e.g. "beguiling day" this folder structure changes to `export_data/beguiling_day/transcript.txt`

# Test Plan
- [x] test on mac
- [ ] end-to-end test on qubes 