### PR TITLE
Update apparmor to allow securedrop-client to execute /usr/lib/qubes/qfile-agent

### DIFF
--- a/client/files/usr.bin.securedrop-client
+++ b/client/files/usr.bin.securedrop-client
@@ -39,6 +39,7 @@
   /usr/bin/expr ix,
   /usr/bin/mkdir mrix,
   /usr/bin/qrexec-client-vm mrix,
+  /usr/lib/qubes/qfile-agent ix,
   /usr/bin/qubes-gpg-client mrix,
   /usr/bin/qubes-gpg-import-key mrix,
   /usr/bin/qubesdb-cmd mrix,


### PR DESCRIPTION
## Status
In order to export to whistleflow, securedrop-client needs to be able to execute qfile-agent - see https://github.com/guardian/securedrop-client/blob/870dc04ab4cbdc1d411a96bf9c10f55c4118e64b/securedrop_client/export.py#L201

This change updates the apparmor configuration to allow this. 

## Test Plan
I've tested this on my local securedrop dev machine and verified that it works. 