### PR TITLE
Disable nightlies workflow triggers.

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,10 +1,6 @@
 name: Nightlies
 on:
-  schedule:
-    - cron: "0 6 * * *"
-  push:
-    branches:
-      - main
+  workflow_dispatch: 
 
 # Only allow one job to run at a time because we're pushing to git repos;
 # the string value doesn't matter, just that it's a fixed string.


### PR DESCRIPTION
## Status
This workflow creates nightly builds of securedrop-client. It is currently wired up to push to the freedomofpress securedrop-client repo, which we obviously don't want to push to from our fork. I don't think we'll be making changes quickly enough to our fork to justify building nightly builds of it.

I've left the actual workflow itself in just to minimise the diff between our fork and the origin repo


