### PR TITLE
Show full timestamp for message last updated time

### DIFF
--- a/client/securedrop_client/gui/datetime_helpers.py
+++ b/client/securedrop_client/gui/datetime_helpers.py
@@ -30,3 +30,16 @@ def format_datetime_local(date: datetime.datetime) -> str:
     Localise date and return as a string in the format e.g. Sep 16
     """
     return format_datetime_month_day(localise_datetime(date))
+
+# Below functions unique to guardian fork - timestamps excluded in FPF version for security reasons
+def format_datetime_month_day_time(date: datetime.datetime) -> str:
+    """
+    Formats date as e.g. Sep 16
+    """
+    return arrow.get(date).format("MMM D, HH:mm")
+
+def format_datetime_local_timestamp(date: datetime.datetime) -> str:
+    """
+    Localise date and return as a string in the format e.g. Sep 16
+    """
+    return format_datetime_month_day_time(localise_datetime(date))

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -85,7 +85,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
-from securedrop_client.gui.datetime_helpers import format_datetime_local
+from securedrop_client.gui.datetime_helpers import format_datetime_local_timestamp
 from securedrop_client.gui.shortcuts import Shortcuts
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
@@ -1525,7 +1525,7 @@ class SourceWidget(QWidget):
     SPACER = 14
     BOTTOM_SPACER = 11
     STAR_WIDTH = 20
-    TIMESTAMP_WIDTH = 60
+    TIMESTAMP_WIDTH = 80
 
     SOURCE_NAME_CSS = load_css("source_name.css")
     SOURCE_PREVIEW_CSS = load_css("source_preview.css")
@@ -1616,11 +1616,11 @@ class SourceWidget(QWidget):
         self.spacer.setFixedWidth(self.SPACER)
         source_widget_layout.addWidget(self.spacer, 0, 1, 1, 1)
         source_widget_layout.addWidget(self.name, 0, 2, 1, 1)
-        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1)
+        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addWidget(self.paperclip_disabled, 0, 3, 1, 1)
         source_widget_layout.addWidget(self.preview, 1, 2, 1, 1, alignment=Qt.AlignLeft)
         source_widget_layout.addWidget(self.deletion_indicator, 1, 2, 1, 1)
-        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1)
+        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addItem(QSpacerItem(self.BOTTOM_SPACER, self.BOTTOM_SPACER))
         self.source_widget.setLayout(source_widget_layout)
         layout = QHBoxLayout(self)
@@ -1652,7 +1652,7 @@ class SourceWidget(QWidget):
         try:
             self.controller.session.refresh(self.source)
             self.last_updated = self.source.last_updated
-            self.timestamp.setText(_(format_datetime_local(self.source.last_updated)))
+            self.timestamp.setText(_(format_datetime_local_timestamp(self.source.last_updated)))
             self.name.setText(self.source.journalist_designation)
 
             self.set_snippet(self.source_uuid)
@@ -3852,7 +3852,7 @@ class SourceProfileShortWidget(QWidget):
             self.MARGIN_LEFT, self.VERTICAL_MARGIN, self.MARGIN_RIGHT, self.VERTICAL_MARGIN
         )
         title = TitleLabel(self.source.journalist_designation)
-        self.updated = LastUpdatedLabel(_(format_datetime_local(self.source.last_updated)))
+        self.updated = LastUpdatedLabel(_(format_datetime_local_timestamp(self.source.last_updated)))
         menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
@@ -3873,4 +3873,4 @@ class SourceProfileShortWidget(QWidget):
         Ensure the timestamp is always kept up to date with the latest activity
         from the source.
         """
-        self.updated.setText(_(format_datetime_local(self.source.last_updated)))
+        self.updated.setText(_(format_datetime_local_timestamp(self.source.last_updated)))

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -98,6 +98,7 @@ logger = logging.getLogger(__name__)
 
 MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
 NO_DELAY = 1
+LAST_UPDATED_LABEL_TOOLTIP="Time of last activity from source"
 
 
 class BottomPane(QWidget):
@@ -1594,6 +1595,7 @@ class SourceWidget(QWidget):
         self.timestamp.setSizePolicy(retain_space)
         self.timestamp.setFixedWidth(self.TIMESTAMP_WIDTH)
         self.timestamp.setObjectName("SourceWidget_timestamp")
+        self.timestamp.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
         # Create source_widget:
         # -------------------------------------------------------------------
@@ -3812,6 +3814,7 @@ class LastUpdatedLabel(QLabel):
 
         # Set CSS id
         self.setObjectName("LastUpdatedLabel")
+        self.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
 
 class SourceProfileShortWidget(QWidget):


### PR DESCRIPTION
## Description
This change modifies the securedrop UI so that the time of the most recent message sent by the source is shown in the UI (as opposed to just the month an the day).

There's quite a bit of prior discussion on whether this is a good idea or not - see the issues below for furth details. From the guardian's perspective, we think having the time is extremely valuable when working in a multi user environment

Replaces https://github.com/guardian/securedrop-client/pull/11 and is related to:

 - https://github.com/freedomofpress/securedrop-client/issues/1563
 - https://github.com/freedomofpress/securedrop-client/issues/538

It looks like this:
![shot](https://github.com/user-attachments/assets/68b7508c-06f2-4817-9664-e1219915ffab)

## Test Plan


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
